### PR TITLE
Replace skip_only with nomove functionality

### DIFF
--- a/replan
+++ b/replan
@@ -50,7 +50,7 @@ if __FILE__ == $PROGRAM_NAME
   options = SimpleScripting::Argv.decode(
     [ "-c", "--compare", "Compare before replacing the file, if there is any change, and ask confirmation" ],
     [ "-l", "--list",    "List mode"],
-    [ "-s", "--skip",    "Move skipped events (for all the days)"],
+    [ "-M", "--nomove",  "Don't move the current day after applying the replans"],
   ) || exit
 
   configuration = SimpleScripting::Configuration.load
@@ -58,22 +58,14 @@ if __FILE__ == $PROGRAM_NAME
   schedule_filename = configuration.schedule_filename.full_path
   archive_filename = configuration.archive_filename.full_path
 
+  move = !options[:nomove]
+
   if options[:list]
     raise "List mode is not compatible with other options" if options.size > 1
 
     content = IO.read(schedule_filename)
 
     Relister.new.execute(content)
-  elsif options[:skip] # falsey :list implied
-    content = IO.read(schedule_filename)
-    original_content = content.dup
-
-    # Refix, otherwise replanner may hit an unfixed date.
-    #
-    content = Refixer.new.execute(content)
-    content = Replanner.new.execute(content, skip_only: true)
-
-    conditional_save(content, original_content, schedule_filename, archive_filename, compare: true, move: false)
   else
     content = IO.read(schedule_filename)
     original_content = content.dup
@@ -81,8 +73,8 @@ if __FILE__ == $PROGRAM_NAME
     content = Refixer.new.execute(content)
     content = Readder.new.execute(content)
     content = Reworker.new.execute(content)
-    content = Replanner.new.execute(content)
+    content = Replanner.new.execute(content, move)
 
-    conditional_save(content, original_content, schedule_filename, archive_filename, compare: options[:compare], move: true)
+    conditional_save(content, original_content, schedule_filename, archive_filename, compare: options[:compare], move: move)
   end
 end

--- a/replan.lib/replanner.rb
+++ b/replan.lib/replanner.rb
@@ -9,13 +9,15 @@ class Replanner
     @replan_codec = ReplanCodec.new
   end
 
-  def execute(content, skip_only: false)
+  # check_todo: if true and a todo section is found, an error is raised.
+  #
+  def execute(content, check_todo)
     dates = find_all_dates(content)
 
     dates.each_with_index do |current_date, date_i|
       current_date_section = find_date_section(content, current_date)
 
-      if !skip_only && current_date_section =~ CURRENT_TIME_SEPARATOR_REGEX
+      if check_todo && current_date_section =~ CURRENT_TIME_SEPARATOR_REGEX
         raise "Found todo section!"
       end
 
@@ -27,9 +29,7 @@ class Replanner
       # so that they will appear in the original order.
       #
       replan_lines.reverse.each do |replan_line|
-        skip_date = (date_i == 0 && skip_only && !@replan_codec.skipped_event?(replan_line)) ||
-                    (date_i > 0 && !@replan_codec.skipped_event?(replan_line))
-        next if skip_date
+        next if date_i > 0 && !@replan_codec.skipped_event?(replan_line)
 
         is_fixed, fixed_time, is_skipped, no_replan, planned_date = decode_planned_date(replan_line, current_date)
 


### PR DESCRIPTION
Now that skipped events for all the days are moved in regular mode, the :skip_only mode can be simplified, by replacing it with a "no-move" functionality.