### PR TITLE
Reworker: Fail fast on invalid work lines

### DIFF
--- a/replan.lib/reworker.rb
+++ b/replan.lib/reworker.rb
@@ -30,19 +30,15 @@ class Reworker
   end
 
   def extract_work_times(section)
-    work_task_matches = section.scan(WORK_TASK_PATTERN)
-
     all_lines_with_work = section.lines.grep(/\bwork\b/)
 
-    if work_task_matches.count != all_lines_with_work.count
-      puts "Mismatching number of work lines!",
-           work_task_matches.to_s,
-           "================",
-           all_lines_with_work.inspect
-      exit 1
-    end
+    times = all_lines_with_work.map do |work_line|
+      work_line_match = work_line.match(WORK_TASK_PATTERN)
 
-    times = work_task_matches.map do |raw_time, raw_description|
+      raise "Unexpected work line format: #{work_line.strip}" if work_line_match.nil?
+
+      raw_time, raw_description = work_line_match[1, 2]
+
       # For the `raw_time` format, see WORK_TASK_PATTERN.
       #
       time = raw_time[1...-1] if raw_time

--- a/spec/replan/replan.lib/reworker_spec.rb
+++ b/spec/replan/replan.lib/reworker_spec.rb
@@ -49,4 +49,16 @@ describe Reworker do
 
     expect(result).to eql(expected_result)
   end
+
+  it 'raises an error when an unexpected work line format is found' do
+    content = <<~TEXT
+          MON 07/JUN/2021
+      - 9:00. work -10:00
+      X work 30
+      - etc
+
+    TEXT
+
+    expect { subject.execute(content) }.to raise_error(RuntimeError, "Unexpected work line format: X work 30")
+  end
 end # describe Reworker


### PR DESCRIPTION
The previous stategy of collecting all the lines produced a hard to read result.